### PR TITLE
Ensure that spawned apps like dpkg are using C messages

### DIFF
--- a/src/tuxedo-tomte
+++ b/src/tuxedo-tomte
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with TUXEDO Tomte. If not, see <https://www.gnu.org/licenses/>.
 
+$ENV{LC_MESSAGES} = 'C';
+
 use strict qw(vars subs);
 use warnings;
 


### PR DESCRIPTION
It prevents errors (in a french system for example):

```
Use of uninitialized value  in concatenation (.) or string at src/tuxedo-tomte line 4357.
E: Aucun paquet n'a été trouvé
Use of uninitialized value  in concatenation (.) or string at src/tuxedo-tomte line 4357.
E: Aucun paquet n'a été trouvé
Use of uninitialized value  in concatenation (.) or string at src/tuxedo-tomte line 4357.
E: Aucun paquet n'a été trouvé
Use of uninitialized value  in concatenation (.) or string at src/tuxedo-tomte line 4357.
E: Aucun paquet n'a été trouvé
Use of uninitialized value  in concatenation (.) or string at src/tuxedo-tomte line 4357.
E: Aucun paquet n'a été trouvé
Use of uninitialized value  in concatenation (.) or string at src/tuxedo-tomte line 4357.
E: Aucun paquet n'a été trouvé
```