### PR TITLE
Add missing line break

### DIFF
--- a/src/tuxedo-tomte
+++ b/src/tuxedo-tomte
@@ -8318,7 +8318,7 @@ sub tuxedoDevice {
 # MAIN PROGRAM
 
 if (!tuxedoDevice()) {
-	print 'It seems that this is not a TUXEDO device. Please contact us if this is a mistake';
+	print 'It seems that this is not a TUXEDO device. Please contact us if this is a mistake\n';
 	exit (0);
 }
 


### PR DESCRIPTION
The new prompt should not be on the same line as the error message.