### PR TITLE
Add support for board P64_HJ,HK1

### DIFF
--- a/src/tuxedo-tomte
+++ b/src/tuxedo-tomte
@@ -8097,6 +8097,9 @@ sub reportPlannedChanges {
 #
 sub tuxedoDevice {
 	if ((defined $boardname) && (defined $boardvendor) && (defined $sysvendor)) {
+		if ($boardname =~ /P64_HJ,HK1/) {
+      return (1);
+    }
 		if ($boardname =~ /P65_P67RGRERA/) {
 			return (1);
 		}


### PR DESCRIPTION
After reinstalling Ubuntu on my Tuxedo I needed this change now the Tuxedo Control Center is working again as before.