### PR TITLE
Fix missing diamond operator in isTextInFile

### DIFF
--- a/src/tuxedo-tomte
+++ b/src/tuxedo-tomte
@@ -5173,7 +5173,7 @@ sub isTextInFile {
 			printLog("Filehandle NOT defined for $filename", 'TL0', '[WARN]');
 			return (0);
 		}
-		while( $FH ) {
+		while( <$FH> ) {
 			if ( $_ =~ /$match/sm) {
 				return (1);
 			}


### PR DESCRIPTION
Without the diamond operator it caused the loop to run forever. 
Output from my system: ```Use of uninitialized value $_ in pattern match (m//) at /usr/bin/tuxedo-tomte line 5177.```